### PR TITLE
Add custom `_document` with `lang` attribute

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+ 
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}


### PR DESCRIPTION
Hey, found your site whilst browsing through Twitter & loved it. Though one small issue I noticed when I ran a [Lighthouse](https://developer.chrome.com/docs/lighthouse/overview/) test was that the sites accessibility score was just shy of the "perfect score" where you get 100's on everything.

This PR will fix that by adding a custom document file ([Documentation](https://nextjs.org/docs/pages/building-your-application/routing/custom-document)) & also adds a `lang` attribute & sets it to `en` (English) which should fix the final accessibility issue.

## Before

<img width="750" alt="Screenshot 2023-05-25 at 4 32 38 pm" src="https://github.com/developedbytoby/website/assets/4991309/a977ae7c-8a73-479e-b0cf-e6d995462ecb">

## After

(The "Best Practices" issues are due to running the locally on a GitHub Codespace rather than a production deployment)

<img width="744" alt="Screenshot 2023-05-25 at 4 36 46 pm" src="https://github.com/developedbytoby/website/assets/4991309/4f313d2f-cd68-48de-b7e4-b35e013fed9d">
